### PR TITLE
Bug parity check

### DIFF
--- a/driver/devices/hi3593.c
+++ b/driver/devices/hi3593.c
@@ -260,7 +260,7 @@ static void hi3593_get_arinc429rx(struct avionics_arinc429rx *config,
 	}
 
 	status = hi3593_get_cntrl(priv);
-	config->flags = (status&0xfe) | (priv->rx_config.flags&0x01);
+	config->flags = (status&0xfe) | ((priv->rx_config.flags)&0x01);
 
 	if (priv->rx_index == 0) {
 		rd_priority = HI3593_OPCODE_RD_RX1_PRIORITY;

--- a/driver/devices/hi3593.c
+++ b/driver/devices/hi3593.c
@@ -305,7 +305,7 @@ static int hi3593_set_arinc429rx(struct avionics_arinc429rx *config,
 		return -ENODEV;
 	}
 
-	err = hi3593_set_cntrl(priv, config->flags, 0xff);
+	err = hi3593_set_cntrl(priv, config->flags, 0xfe);
 	if (err < 0) {
 		pr_err("avionics-hi3593: Failed to set rx control.\n");
 		return err;

--- a/driver/devices/hi3593.c
+++ b/driver/devices/hi3593.c
@@ -714,7 +714,7 @@ static int hi3593_rx_worker_priority(struct hi3593_priv *priv, avionics_data *da
             }
 
             if (!check_parity ||
-               (even_parity && (0x80&buffer[0])) ||
+               (even_parity && (0x80&buffer[0]) != 0x00) ||
                (!even_parity && (0x80&buffer[0]) == 0x00)) {
 
                 if (check_parity && even_parity) {
@@ -861,7 +861,7 @@ static void hi3593_rx_worker(struct work_struct *work)
 				data->length += buffer_size;
             } else {
                 for (j = 0; j < buffer_size; j+=sizeof(__u32)) {
-					if ((even_parity && (0x80&buffer[j])) ||
+					if ((even_parity && (0x80&buffer[j]) != 0x00) ||
 					   (!even_parity && (0x80&buffer[j]) == 0x00)) {
 
 						if (even_parity) {

--- a/driver/devices/hi3593.c
+++ b/driver/devices/hi3593.c
@@ -260,7 +260,7 @@ static void hi3593_get_arinc429rx(struct avionics_arinc429rx *config,
 	}
 
 	status = hi3593_get_cntrl(priv);
-	config->flags = status;
+	config->flags = (status&0xfe) | (priv->rx_config.flags&0x01);
 
 	if (priv->rx_index == 0) {
 		rd_priority = HI3593_OPCODE_RD_RX1_PRIORITY;

--- a/driver/devices/hi3593.c
+++ b/driver/devices/hi3593.c
@@ -276,7 +276,7 @@ static void hi3593_get_arinc429rx(struct avionics_arinc429rx *config,
 	err = spi_write_then_read(priv->spi, &rd_priority, sizeof(rd_priority),
 				  config->priority_labels, 3);
 	if (err) {
-		pr_err("avionics-hi3593: Failed to get rx priorty labels: %d\n",
+		pr_err("avionics-hi3593: Failed to get rx priority labels: %d\n",
 			   err);
 	}
 

--- a/driver/devices/hi3593.c
+++ b/driver/devices/hi3593.c
@@ -713,9 +713,9 @@ static int hi3593_rx_worker_priority(struct hi3593_priv *priv, avionics_data *da
                 return -1;
             }
 
-            if(!check_parity ||
+            if (!check_parity ||
                (even_parity && (0x80&buffer[0])) ||
-               ((0x80&buffer[0]) == 0x00)) {
+               (!even_parity && (0x80&buffer[0]) == 0x00)) {
 
                 if (check_parity && even_parity) {
                     buffer[0] &= 0x7f;
@@ -861,10 +861,10 @@ static void hi3593_rx_worker(struct work_struct *work)
 				data->length += buffer_size;
             } else {
                 for (j = 0; j < buffer_size; j+=sizeof(__u32)) {
-					if((even_parity && (0x80&buffer[j])) ||
-					   ((0x80&buffer[j]) == 0x00)) {
+					if ((even_parity && (0x80&buffer[j])) ||
+					   (!even_parity && (0x80&buffer[j]) == 0x00)) {
 
-						if (check_parity && even_parity) {
+						if (even_parity) {
 							buffer[j] &= 0x7f;
 						}
 

--- a/driver/devices/hi3593.c
+++ b/driver/devices/hi3593.c
@@ -305,7 +305,7 @@ static int hi3593_set_arinc429rx(struct avionics_arinc429rx *config,
 		return -ENODEV;
 	}
 
-	err = hi3593_set_cntrl(priv, config->flags, 0xfe);
+	err = hi3593_set_cntrl(priv, config->flags, 0xff);
 	if (err < 0) {
 		pr_err("avionics-hi3593: Failed to set rx control.\n");
 		return err;


### PR DESCRIPTION
From https://github.com/ccxtechnologies/builder/issues/3470#issuecomment-1864843726
Test Cases

Rate = 12500
- Sending odd parity from simulator
    - Parity check disabled and odd parity: receiving data as expected
    - Parity check disabled and even parity: receiving data as expected
    - Parity check enabled and odd parity: receiving data as expected
    - Parity check enabled and even parity: not receiving data as expected
- Sending even parity from simulator
    - Parity check disabled and odd parity: receiving data as expected
    - Parity check disabled and even parity: receiving data as expected
    - Parity check enabled and odd parity: not receiving data as expected
    - Parity check enabled and even parity: receiving data as expected

Rate = 100000
- Sending odd parity from simulator
    - Parity check disabled and odd parity: receiving data as expected
    - Parity check disabled and even parity: receiving data as expected
    - Parity check enabled and odd parity: receiving data as expected
    - Parity check enabled and even parity: not receiving data as expected
- Sending even parity from simulator
    - Parity check disabled and odd parity: receiving data as expected
    - Parity check disabled and even parity: receiving data as expected
    - Parity check enabled and odd parity: not receiving data as expected
    - Parity check enabled and even parity: receiving data as expected